### PR TITLE
Fix: macOS aarch64 target not found during installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,14 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             ext: tar.gz
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            ext: tar.gz
           - os: macos-latest
             target: x86_64-apple-darwin
+            ext: tar.gz
+          - os: macos-latest
+            target: aarch64-apple-darwin
             ext: tar.gz
           - os: windows-latest
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
Added aarch64 target to release workflow for mac and linux