### PR TITLE
Updated windows installation path to .mux/bin

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -40,7 +40,7 @@ if ([string]::IsNullOrWhiteSpace($InstallDir)) {
     $InstallDir = Join-Path $env:ProgramFiles "mux\bin"
   }
   else {
-    $InstallDir = Join-Path $HOME "bin"
+    $InstallDir = Join-Path $HOME ".mux\bin"
   }
 }
 


### PR DESCRIPTION
The default path was set to $HOME/bin which doesn't fit with standard installation paths, so we have updated the default installation path to $HOME/.mux/bin for user