### PR TITLE
Added platform specific generators for cmake presets

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -676,6 +676,7 @@ const CMAKE_PRESETS: &str = r#"{
     {
       "name": "unix-debug",
       "displayName": "Unix Debug",
+      "generator": "Unix Makefiles",
       "description": "Debug build preset for Linux/macOS",
       "binaryDir": "${sourceDir}/out/unix-debug",
       "cacheVariables": {
@@ -700,6 +701,7 @@ const CMAKE_PRESETS: &str = r#"{
     {
       "name": "unix-release",
       "displayName": "Unix Release",
+      "generator": "Unix Makefiles",
       "description": "Release build preset for Linux/macOS",
       "binaryDir": "${sourceDir}/out/unix-release",
       "cacheVariables": {
@@ -724,6 +726,7 @@ const CMAKE_PRESETS: &str = r#"{
     {
       "name": "windows-debug",
       "displayName": "Windows Debug",
+      "generator": "MinGW Makefiles",
       "description": "Debug build preset for Windows",
       "binaryDir": "${sourceDir}/out/windows-debug",
       "cacheVariables": {
@@ -738,6 +741,7 @@ const CMAKE_PRESETS: &str = r#"{
     {
       "name": "windows-release",
       "displayName": "Windows Release",
+      "generator": "MinGW Makefiles",
       "description": "Release build preset for Windows",
       "binaryDir": "${sourceDir}/out/windows-release",
       "cacheVariables": {


### PR DESCRIPTION
The `mux build` on windows failed because of nmake doesn't exist.. so we defaulted to `MinGW Makefiles` for Windows and `Unix Makefiles` for unix systems