### PR TITLE
Replaced MinGW Makefiles and Unix Makefiles with Ninja build for both Windows and Unix systems

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -676,7 +676,7 @@ const CMAKE_PRESETS: &str = r#"{
     {
       "name": "unix-debug",
       "displayName": "Unix Debug",
-      "generator": "Unix Makefiles",
+      "generator": "Ninja",
       "description": "Debug build preset for Linux/macOS",
       "binaryDir": "${sourceDir}/out/unix-debug",
       "cacheVariables": {
@@ -701,7 +701,7 @@ const CMAKE_PRESETS: &str = r#"{
     {
       "name": "unix-release",
       "displayName": "Unix Release",
-      "generator": "Unix Makefiles",
+      "generator": "Ninja",
       "description": "Release build preset for Linux/macOS",
       "binaryDir": "${sourceDir}/out/unix-release",
       "cacheVariables": {
@@ -726,7 +726,7 @@ const CMAKE_PRESETS: &str = r#"{
     {
       "name": "windows-debug",
       "displayName": "Windows Debug",
-      "generator": "MinGW Makefiles",
+      "generator": "Ninja",
       "description": "Debug build preset for Windows",
       "binaryDir": "${sourceDir}/out/windows-debug",
       "cacheVariables": {
@@ -741,7 +741,7 @@ const CMAKE_PRESETS: &str = r#"{
     {
       "name": "windows-release",
       "displayName": "Windows Release",
-      "generator": "MinGW Makefiles",
+      "generator": "Ninja",
       "description": "Release build preset for Windows",
       "binaryDir": "${sourceDir}/out/windows-release",
       "cacheVariables": {


### PR DESCRIPTION
- Replaced `MinGW Makefiles` for `windows-debug` and `windows-release` cmake presets with `Ninja` for Windows
- Replaced `Unix Makefiles` for `unix-debug` and `unix-release` cmake presets with `Ninja` for Linux or Unix